### PR TITLE
Fix package name in installation success message

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -186,7 +186,7 @@ def run_apt_install(package, backup_path=None):
             if 'newest version' in line:
                 print_c(line, TextColors.GREEN)
                 return
-        print_c("Successfully installed python3-dev", TextColors.GREEN)
+        print_c("Successfully installed {}".format(package), TextColors.GREEN)
 
 def update_package_list(backup_path=None):
     print("Updating package list...")


### PR DESCRIPTION
python3-dev is hard-coded here, so when run_apt_install() succeeds installing python3-venv, this message is repeated erroneously.